### PR TITLE
travis.sh: generalize to support new LyX versions

### DIFF
--- a/development/cmake/scripts/travis.sh
+++ b/development/cmake/scripts/travis.sh
@@ -257,7 +257,7 @@ mv $builddir/FindQt4.cmake ../lyx/development/cmake/modules/
 make package
 checkExitCode
 
-mv LyX22-2.2.0-win32.zip $branch.zip
+mv LyX??-?.?.0-win32.zip $branch.zip
 
 if [ ! -e $branch.zip ]; then
     exit 1


### PR DESCRIPTION
This script had a filename that was specific to LyX 2.2.0.
